### PR TITLE
Fix missing include

### DIFF
--- a/src/utils/net/WeightsStorage.cpp
+++ b/src/utils/net/WeightsStorage.cpp
@@ -3,6 +3,7 @@
 #include "../HaltonSequence.hpp"
 #include "../minitrace/minitrace.h"
 
+#include <algorithm>
 #include <random>
 
 namespace nn {


### PR DESCRIPTION
File src/utils/net/WeightsStorage.cpp is missing an include for \<algorithm\>, required by std::clamp(). Fix this.

**

Without this change, Caissa fails to build on Ubuntu 23.04 with the following error message:

```
% make -j
[  1%] Building CXX object src/backend/CMakeFiles/backend.dir/Evaluate.cpp.o
[  3%] Linking CXX static library ../../lib/libbackend.a
[ 46%] Built target backend
[ 48%] Building CXX object src/frontend/CMakeFiles/caissa.dir/UCI.cpp.o
[ 50%] Building CXX object src/utils/CMakeFiles/utils.dir/net/WeightsStorage.cpp.o
/home/skiminki/projects/Caissa/src/utils/net/WeightsStorage.cpp: In member function ‘void nn::WeightsStorage::Update_Adadelta(const nn::Gradients&, const WeightsUpdateOptions&)’:
/home/skiminki/projects/Caissa/src/utils/net/WeightsStorage.cpp:172:26: error: ‘clamp’ is not a member of ‘std’
  172 |                 w = std::clamp(w, -maxWeightValue, maxWeightValue);
      |                          ^~~~~
/home/skiminki/projects/Caissa/src/utils/net/WeightsStorage.cpp: In member function ‘void nn::WeightsStorage::Update_Adam(const nn::Gradients&, const WeightsUpdateOptions&)’:
/home/skiminki/projects/Caissa/src/utils/net/WeightsStorage.cpp:291:26: error: ‘clamp’ is not a member of ‘std’
  291 |                 w = std::clamp(w, -maxWeightValue, maxWeightValue);
      |                          ^~~~~
```

The header to include is documented in https://en.cppreference.com/w/cpp/algorithm/clamp .